### PR TITLE
바이트 배열을 인코딩하는 BaseXEncodeService 개발 

### DIFF
--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/BaseXEncodeService.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/BaseXEncodeService.java
@@ -1,0 +1,53 @@
+package io.github.daengdaenglee.mangurl.application.mangle.service;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+import java.util.LinkedList;
+
+@Service
+class BaseXEncodeService {
+    private final char[] codec;
+    private final BigInteger base;
+
+    BaseXEncodeService() {
+        this.codec = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+        this.base = new BigInteger(String.valueOf(this.codec.length));
+    }
+
+    BaseXEncodeService(String codec) {
+        this.codec = codec.toCharArray();
+        this.base = new BigInteger(String.valueOf(this.codec.length));
+    }
+
+    String encode(byte[] bytes) {
+        if (bytes.length == 0) {
+            return "";
+        }
+
+        var paddedBytes = this.padLeadingZero(bytes);
+        var value = new BigInteger(paddedBytes);
+
+        var buffer = new LinkedList<Character>();
+        while (value.compareTo(this.base) > 0) {
+            var c = this.codec[value.remainder(this.base).intValue()];
+            buffer.addFirst(c);
+            value = value.divide(this.base);
+        }
+        buffer.addFirst(this.codec[value.intValue()]);
+
+        var sb = new StringBuilder();
+        buffer.forEach(sb::append);
+        return sb.toString();
+    }
+
+    /**
+     * BigInteger 로 변환했을 때 항상 양수로 만들기 위해 부호 바이트 0 을 항상 추가
+     * BigInteger 는 big 엔디언 방식으로 동작하므로 앞에 0 을 붙이는 건 값 변경은 없음
+     */
+    private byte[] padLeadingZero(byte[] bytes) {
+        var padded = new byte[bytes.length + 1];
+        System.arraycopy(bytes, 0, padded, 1, bytes.length);
+        return padded;
+    }
+}

--- a/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/BaseXEncodeServiceTest.java
+++ b/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/BaseXEncodeServiceTest.java
@@ -1,0 +1,82 @@
+package io.github.daengdaenglee.mangurl.application.mangle.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BaseXEncodeServiceTest {
+    @Test
+    @DisplayName("빈 byte 배열을 입력하면 빈 문자열을 반환한다.")
+    void encodeBase62Empty() {
+        // given
+        var bytes = new byte[]{};
+        var baseXEncodeService = new BaseXEncodeService();
+
+        // when
+        var encoded = baseXEncodeService.encode(bytes);
+
+        // then
+        assertThat(encoded).isEmpty();
+    }
+
+    @Test
+    @DisplayName("입력한 byte 배열을 62진법으로 변환한다.")
+    void encodeBase62() {
+        // given
+        var codec = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        var expected = "aB3";
+        var bytes = this.toByteArray(codec, expected);
+        var baseXEncodeService = new BaseXEncodeService();
+
+        // when
+        var encoded = baseXEncodeService.encode(bytes);
+
+        // then
+        assertThat(encoded).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("입력한 byte 배열을 16진법으로 변환한다.")
+    void encodeBase16() {
+        // given
+        var codec = "0123456789abcdef";
+        var expected = "ab3";
+        var bytes = this.toByteArray(codec, expected);
+        var baseXEncodeService = new BaseXEncodeService(codec);
+
+        // when
+        var encoded = baseXEncodeService.encode(bytes);
+
+        // then
+        assertThat(encoded).isEqualTo(expected);
+    }
+
+    private byte[] toByteArray(String codec, String value) {
+        var codecList = codec.chars()
+                .mapToObj(c -> (char) c)
+                .toList();
+        var base = codecList.size();
+        var charArray = value.toCharArray();
+        return IntStream.range(0, charArray.length)
+                .mapToObj(i -> {
+                    var c = charArray[i];
+                    var cIndex = codecList.indexOf(c);
+                    if (cIndex < 0) {
+                        throw new RuntimeException("잘못된 codec 입니다.");
+                    }
+                    var a = BigInteger.valueOf(cIndex);
+
+                    var j = charArray.length - 1 - i;
+                    var b = BigInteger.valueOf(base).pow(j);
+
+                    return a.multiply(b);
+                })
+                .reduce(BigInteger::add)
+                .map(BigInteger::toByteArray)
+                .orElse(new byte[]{});
+    }
+}


### PR DESCRIPTION
## 개요

- related issue : #1 
- 해싱한 결과물인 바이트 배열을 특정 진법 표현의 문자열로 인코딩하는 기능 제공

## 변경 내용

- BaseXEncodeService 추가
- 바이트 배열을 인코딩하는 메소드 개발
- 생성자를 통해 진법을 선택할 수 있도록 개발, 기본값은 62진법, Base64 의 코덱에서 특수문자만 제외한 코덱 사용
- 62진법, 16진법에 대해 테스트
- 빈 배열인 엣지 케이스 테스트 
