### PR TITLE
BaseXEncodeService 를 62진법에 특화된 형태로 수정

### DIFF
--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/Base62EncodeService.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/Base62EncodeService.java
@@ -6,19 +6,11 @@ import java.math.BigInteger;
 import java.util.LinkedList;
 
 @Service
-class BaseXEncodeService {
-    private final char[] codec;
-    private final BigInteger base;
+class Base62EncodeService {
+    static final String CODEC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-    BaseXEncodeService() {
-        this.codec = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
-        this.base = new BigInteger(String.valueOf(this.codec.length));
-    }
-
-    BaseXEncodeService(String codec) {
-        this.codec = codec.toCharArray();
-        this.base = new BigInteger(String.valueOf(this.codec.length));
-    }
+    private final char[] codec = CODEC.toCharArray();
+    private final BigInteger base = new BigInteger(String.valueOf(this.codec.length));
 
     String encode(byte[] bytes) {
         if (bytes.length == 0) {

--- a/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/Base62EncodeServiceTest.java
+++ b/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/Base62EncodeServiceTest.java
@@ -8,13 +8,13 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class BaseXEncodeServiceTest {
+class Base62EncodeServiceTest {
     @Test
     @DisplayName("빈 byte 배열을 입력하면 빈 문자열을 반환한다.")
     void encodeBase62Empty() {
         // given
         var bytes = new byte[]{};
-        var baseXEncodeService = new BaseXEncodeService();
+        var baseXEncodeService = new Base62EncodeService();
 
         // when
         var encoded = baseXEncodeService.encode(bytes);
@@ -27,10 +27,9 @@ class BaseXEncodeServiceTest {
     @DisplayName("입력한 byte 배열을 62진법으로 변환한다.")
     void encodeBase62() {
         // given
-        var codec = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         var expected = "aB3";
-        var bytes = this.toByteArray(codec, expected);
-        var baseXEncodeService = new BaseXEncodeService();
+        var bytes = this.toByteArray(expected);
+        var baseXEncodeService = new Base62EncodeService();
 
         // when
         var encoded = baseXEncodeService.encode(bytes);
@@ -39,28 +38,12 @@ class BaseXEncodeServiceTest {
         assertThat(encoded).isEqualTo(expected);
     }
 
-    @Test
-    @DisplayName("입력한 byte 배열을 16진법으로 변환한다.")
-    void encodeBase16() {
-        // given
-        var codec = "0123456789abcdef";
-        var expected = "ab3";
-        var bytes = this.toByteArray(codec, expected);
-        var baseXEncodeService = new BaseXEncodeService(codec);
-
-        // when
-        var encoded = baseXEncodeService.encode(bytes);
-
-        // then
-        assertThat(encoded).isEqualTo(expected);
-    }
-
-    private byte[] toByteArray(String codec, String value) {
-        var codecList = codec.chars()
+    private byte[] toByteArray(String expected) {
+        var codecList = Base62EncodeService.CODEC.chars()
                 .mapToObj(c -> (char) c)
                 .toList();
         var base = codecList.size();
-        var charArray = value.toCharArray();
+        var charArray = expected.toCharArray();
         return IntStream.range(0, charArray.length)
                 .mapToObj(i -> {
                     var c = charArray[i];


### PR DESCRIPTION
## 개요

- related issue : #1 
- 일반화된 코드를 필요한 만큼 구체화

## 개발 내용

- 개발중인 서비스에 62진법 변환 이외의 경우가 없다고 판단
- 불필요하게 일반화된 코드를 요구사항에 맞는 수준으로 구체화 
- 클래스 이름도 BaseX 에서 Base62 로 변경 