### PR TITLE
HashService 내 중복 로직 공통 메소드로 모으기

### DIFF
--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/HashService.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/HashService.java
@@ -24,8 +24,6 @@ class HashService {
     }
 
     byte[] hash(String message, String salt) {
-        var saltedMessage = message + salt;
-        this.md.update(saltedMessage.getBytes(StandardCharsets.UTF_8));
-        return md.digest();
+        return this.hash(message + salt);
     }
 }


### PR DESCRIPTION
## 개요

- related issue : #1 
- HashService 내 중복 로직을 하나의 메소드를 사용하도록 수정 

## 내용

- MessageDigest 사용하는 코드 한 메소드에 모으기 