### PR TITLE
긴 URL 을 7자리 코드로 단축하는 기능 개발 

### DIFF
--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleService.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleService.java
@@ -1,0 +1,33 @@
+package io.github.daengdaenglee.mangurl.application.mangle.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MangleService {
+    private final HashService hashService;
+    private final Base62EncodeService base62EncodeService;
+
+    private final int len = 7;
+
+    public String mangle(String longUrl) {
+        var hashed = this.hashService.hash(longUrl);
+        var encoded = this.base62EncodeService.encode(hashed);
+        var sliced = this.slice(encoded);
+        return this.padZero(sliced);
+    }
+
+    private String slice(String value) {
+        var endIndex = Math.min(this.len, value.length());
+        return value.substring(0, endIndex);
+    }
+
+    private String padZero(String value) {
+        if (value.length() >= this.len) {
+            return value;
+        }
+        var n = this.len - value.length();
+        return "0".repeat(n) + value;
+    }
+}

--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleService.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleService.java
@@ -1,17 +1,17 @@
 package io.github.daengdaenglee.mangurl.application.mangle.service;
 
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 @Service
-public class MangleService {
+class MangleService {
     private final HashService hashService;
     private final Base62EncodeService base62EncodeService;
-
     private final int len = 7;
 
-    public String mangle(String longUrl) {
+    String mangle(String longUrl) {
         var hashed = this.hashService.hash(longUrl);
         var encoded = this.base62EncodeService.encode(hashed);
         var sliced = this.slice(encoded);

--- a/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleServiceTest.java
+++ b/src/test/java/io/github/daengdaenglee/mangurl/application/mangle/service/MangleServiceTest.java
@@ -1,0 +1,90 @@
+package io.github.daengdaenglee.mangurl.application.mangle.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MangleServiceTest {
+    private MangleService mangleService;
+
+    private String longUrl1;
+    private String shortUrlCode1;
+    private String longUrl2;
+    private String shortUrlCode2;
+
+    @BeforeEach
+    void beforeEach() {
+        var hashService = new HashService();
+        var base62EncodeService = new Base62EncodeService();
+        this.mangleService = new MangleService(
+                hashService,
+                base62EncodeService);
+
+        this.longUrl1 = "https://google.com";
+        this.longUrl2 = "https://github.com";
+
+        // 미리 hash -> encode -> substring 한 테스트 데이터 준비
+        this.shortUrlCode1 = "Ep0B3mS";
+        this.shortUrlCode2 = "BdrFjrW";
+    }
+
+    @Test
+    @DisplayName("mangle 한 shortUrl 은 7글자여야 한다.")
+    void length7() {
+        // given
+        // longUrl1, longUrl2 사용
+
+        // when
+        var mangled1 = this.mangleService.mangle(this.longUrl1);
+        var mangled2 = this.mangleService.mangle(this.longUrl2);
+
+        // then
+        assertThat(mangled1.length()).isEqualTo(7);
+        assertThat(mangled2.length()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("mangle 한 결과는 hash -> encode -> substring -> 0 padding 한 결과와 같다.")
+    void isEqual() {
+        // given
+        // longUrl1, longUrl2 사용
+
+        // when
+        var mangled1 = this.mangleService.mangle(this.longUrl1);
+        var mangled2 = this.mangleService.mangle(this.longUrl2);
+
+        // then
+        assertThat(mangled1).isEqualTo(this.shortUrlCode1);
+        assertThat(mangled2).isEqualTo(this.shortUrlCode2);
+    }
+
+    @Test
+    @DisplayName("같은 URL 을 넣으면 같은 결과가 나온다.")
+    void sameInputSameOutput() {
+        // given
+        // longUrl1 사용
+
+        // when
+        var mangled1 = this.mangleService.mangle(this.longUrl1);
+        var mangled2 = this.mangleService.mangle(this.longUrl1);
+
+        // then
+        assertThat(mangled1).isEqualTo(mangled2);
+    }
+
+    @Test
+    @DisplayName("다른 URL 을 넣으면 다른 결과가 나온다. (해시 충돌 안 나는 일반적인 상황 테스트)")
+    void diffInputDiffOutput() {
+        // given
+        // longUrl1, longUrl2 사용
+
+        // when
+        var mangled1 = this.mangleService.mangle(this.longUrl1);
+        var mangled2 = this.mangleService.mangle(this.longUrl2);
+
+        // then
+        assertThat(mangled1).isNotEqualTo(mangled2);
+    }
+}


### PR DESCRIPTION
## 개요

- related issue : #1 
- 원본 URL 을 7자리 base62 인코딩된 문자열로 변환하는 기능

## 개발 노트

- 앞서 개발했던 HashService, Base62EncodeService 사용 
- 길이가 7자리에서 부족한 경우 앞에 0을 추가해서 길이를 맞춤 (padLeft)