### PR TITLE
In-Memory URL 데이터 저장소 만들기

### DIFF
--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/DuplicateShortUrlCodeException.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/DuplicateShortUrlCodeException.java
@@ -1,0 +1,4 @@
+package io.github.daengdaenglee.mangurl.application.mangle.outboundport;
+
+public class DuplicateShortUrlCodeException extends RuntimeException {
+}

--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
@@ -3,12 +3,12 @@ package io.github.daengdaenglee.mangurl.application.mangle.outboundport;
 import java.util.Optional;
 
 public interface UrlRepository {
-    Optional<String> readShortUrlCodeByOriginalUrl(String originalUrl);
+    Optional<String> findShortUrlCodeByOriginalUrl(String originalUrl);
 
     /**
      * @throws DuplicateShortUrlCodeException 같은 shortUrlCode 에 다른 originalUrl 이 이미 매핑되어 있는 경우 발생
      */
     void save(String originalUrl, String shortUrlCode);
 
-    Optional<String> readOriginalUrlByShortUrlCode(String shortUrlCode);
+    Optional<String> findOriginalUrlByShortUrlCode(String shortUrlCode);
 }

--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
@@ -1,0 +1,14 @@
+package io.github.daengdaenglee.mangurl.application.mangle.outboundport;
+
+import java.util.Optional;
+
+public interface UrlRepository {
+    Optional<String> readShortUrlCodeByOriginalUrl(String originalUrl);
+
+    /**
+     * @throws DuplicateShortUrlCodeException 같은 shortUrlCode 에 다른 originalUrl 이 이미 매핑되어 있는 경우 발생
+     */
+    void save(String originalUrl, String shortUrlCode);
+
+    Optional<String> readOriginalUrlByShortUrlCode(String shortUrlCode);
+}

--- a/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/application/mangle/outboundport/UrlRepository.java
@@ -3,12 +3,21 @@ package io.github.daengdaenglee.mangurl.application.mangle.outboundport;
 import java.util.Optional;
 
 public interface UrlRepository {
+    /**
+     * 한 originalUrl 에 매핑되어 있는 shortUrlCode 는 유일하다.
+     */
     Optional<String> findShortUrlCodeByOriginalUrl(String originalUrl);
 
     /**
+     * 같은 shortUrlCode 에 다른 originalUrl 이 매핑되지 않도록 해야 한다.
+     * 같은 originalUrl 에 다른 shortUrlCode 이 매핑되는 것은 허용한다.
+     *
      * @throws DuplicateShortUrlCodeException 같은 shortUrlCode 에 다른 originalUrl 이 이미 매핑되어 있는 경우 발생
      */
     void save(String originalUrl, String shortUrlCode);
 
+    /**
+     * 같은 originalUrl 에 다른 shortUrlCode 가 매핑되어 있는 경우 매핑되어 있는 shortUrlCode 중 임의의 shortUrlCode 를 반환한다.
+     */
     Optional<String> findOriginalUrlByShortUrlCode(String shortUrlCode);
 }

--- a/src/main/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepository.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepository.java
@@ -13,7 +13,7 @@ public class InMemoryUrlRepository implements UrlRepository {
     private final ConcurrentHashMap<String, String> shortUrlCodeByOriginalUrl = new ConcurrentHashMap<>();
 
     @Override
-    public Optional<String> readShortUrlCodeByOriginalUrl(String originalUrl) {
+    public Optional<String> findShortUrlCodeByOriginalUrl(String originalUrl) {
         return Optional.ofNullable(this.shortUrlCodeByOriginalUrl.get(originalUrl));
     }
 
@@ -32,7 +32,7 @@ public class InMemoryUrlRepository implements UrlRepository {
     }
 
     @Override
-    public Optional<String> readOriginalUrlByShortUrlCode(String shortUrlCode) {
+    public Optional<String> findOriginalUrlByShortUrlCode(String shortUrlCode) {
         return Optional.ofNullable(this.originalUrlByShortUrlCode.get(shortUrlCode));
     }
 }

--- a/src/main/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepository.java
+++ b/src/main/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepository.java
@@ -1,0 +1,38 @@
+package io.github.daengdaenglee.mangurl.outboundadapter.mangle.repository;
+
+import io.github.daengdaenglee.mangurl.application.mangle.outboundport.DuplicateShortUrlCodeException;
+import io.github.daengdaenglee.mangurl.application.mangle.outboundport.UrlRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryUrlRepository implements UrlRepository {
+    private final ConcurrentHashMap<String, String> originalUrlByShortUrlCode = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> shortUrlCodeByOriginalUrl = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<String> readShortUrlCodeByOriginalUrl(String originalUrl) {
+        return Optional.ofNullable(this.shortUrlCodeByOriginalUrl.get(originalUrl));
+    }
+
+    @Override
+    public void save(String originalUrl, String shortUrlCode) {
+        this.originalUrlByShortUrlCode.compute(shortUrlCode, (key, val) -> {
+            if (val != null && !val.equals(originalUrl)) {
+                throw new DuplicateShortUrlCodeException();
+            }
+            return originalUrl;
+        });
+        // originalUrl 에 여러 shortUrlCode 가 매핑되어 있어도
+        // 어떤 shortUrlCode 를 쓰든 다시 originalUrl 로 매핑할 수 있기 때문에
+        // 최초에 매핑된 것 하나만 유지해도 문제 없음
+        this.shortUrlCodeByOriginalUrl.putIfAbsent(originalUrl, shortUrlCode);
+    }
+
+    @Override
+    public Optional<String> readOriginalUrlByShortUrlCode(String shortUrlCode) {
+        return Optional.ofNullable(this.originalUrlByShortUrlCode.get(shortUrlCode));
+    }
+}

--- a/src/test/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepositoryTest.java
+++ b/src/test/java/io/github/daengdaenglee/mangurl/outboundadapter/mangle/repository/InMemoryUrlRepositoryTest.java
@@ -1,0 +1,152 @@
+package io.github.daengdaenglee.mangurl.outboundadapter.mangle.repository;
+
+import io.github.daengdaenglee.mangurl.application.mangle.outboundport.DuplicateShortUrlCodeException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryUrlRepositoryTest {
+    private final String testOriginalUrl1 = "https://google.com";
+    private final String testOriginalUrl2 = "https://naveer.com";
+    private final String testShortUrlCode1 = "abcdefg";
+    private final String testShortUrlCode2 = "hijklmn";
+
+    @Test
+    @DisplayName("존재하는 originalUrl 로 조회하면 매핑된 shortUrlCode 를 담은 Optional 객체를 반환한다.")
+    void findExistingShortUrlCode() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        var result = urlRepository.findShortUrlCodeByOriginalUrl(this.testOriginalUrl1);
+
+        // then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(this.testShortUrlCode1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 originalUrl 로 조회하면 빈 Optional 객체를 반환한다.")
+    void findNotExistingShortUrlCode() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        var result = urlRepository.findShortUrlCodeByOriginalUrl(this.testOriginalUrl2);
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 originalUrl - shortUrlCode 쌍을 저장할 수 있다.")
+    void saveNotExistingEntry() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        // testOriginalUrl1, testShortUrlCode1 사용
+
+        // when
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // then
+        var originalUrlResult = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode1);
+        assertThat(originalUrlResult.isPresent()).isTrue();
+        assertThat(originalUrlResult.get()).isEqualTo(this.testOriginalUrl1);
+
+        var shortUrlCodeResult = urlRepository.findShortUrlCodeByOriginalUrl(this.testOriginalUrl1);
+        assertThat(shortUrlCodeResult.isPresent()).isTrue();
+        assertThat(shortUrlCodeResult.get()).isEqualTo(this.testShortUrlCode1);
+    }
+
+    @Test
+    @DisplayName("존재하는 originalUrl - shortUrlCode 쌍을 저장하면 현재 상태를 그대로 유지한다.")
+    void saveExistingEntry() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // then
+        var originalUrlResult = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode1);
+        assertThat(originalUrlResult.isPresent()).isTrue();
+        assertThat(originalUrlResult.get()).isEqualTo(this.testOriginalUrl1);
+
+        var shortUrlCodeResult = urlRepository.findShortUrlCodeByOriginalUrl(this.testOriginalUrl1);
+        assertThat(shortUrlCodeResult.isPresent()).isTrue();
+        assertThat(shortUrlCodeResult.get()).isEqualTo(this.testShortUrlCode1);
+    }
+
+    @Test
+    @DisplayName("다른 originalUrl 을 같은 shortUrlCode 와 저장하려고 하면 DuplicateShortUrlCodeException 예외가 발생한다.")
+    void saveDifferentShortUrlCodeWithSameOriginalUrl() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> urlRepository.save(this.testOriginalUrl2, this.testShortUrlCode1))
+                .isInstanceOf(DuplicateShortUrlCodeException.class);
+    }
+
+    @Test
+    @DisplayName("""
+            다른 shortUrlCode 를 같은 originalUrl 과 저장할 수 있다.
+            각 shortUrlCode 에 동일한 originalUrl 이 매핑되고
+            originalUrl 에 처음 shortUrlCode 가 매핑된다.""")
+    void saveDifferentOriginalUrlWithSameShortUrlCode() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode2);
+
+        // then
+        var originalUrlResult1 = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode1);
+        assertThat(originalUrlResult1.isPresent()).isTrue();
+        assertThat(originalUrlResult1.get()).isEqualTo(this.testOriginalUrl1);
+
+        var originalUrlResult2 = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode2);
+        assertThat(originalUrlResult2.isPresent()).isTrue();
+        assertThat(originalUrlResult2.get()).isEqualTo(this.testOriginalUrl1);
+
+        var shortUrlCodeResult = urlRepository.findShortUrlCodeByOriginalUrl(this.testOriginalUrl1);
+        assertThat(shortUrlCodeResult.isPresent()).isTrue();
+        assertThat(shortUrlCodeResult.get()).isEqualTo(this.testShortUrlCode1);
+    }
+
+    @Test
+    @DisplayName("존재하는 shortUrlCode 로 조회하면 매핑된 originalUrl 를 담은 Optional 객체를 반환한다.")
+    void findExistingOriginalUrl() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        var result = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode1);
+
+        // then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(this.testOriginalUrl1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 shortUrlCode 로 조회하면 빈 Optional 객체를 반환한다.")
+    void findNotExistingOriginalUrl() {
+        // given
+        var urlRepository = new InMemoryUrlRepository();
+        urlRepository.save(this.testOriginalUrl1, this.testShortUrlCode1);
+
+        // when
+        var result = urlRepository.findOriginalUrlByShortUrlCode(this.testShortUrlCode2);
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+}


### PR DESCRIPTION
## 개요

- related issue : #10
- shortUrlCode, originalUrl 쌍을 저장하고 조회하는 기능 구현

## 노트

- 같은 shortUrlCode 에 다른 originalUrl 을 저장할 수 없다.
- 같은 originalUrl 에 다른 shortUrlCode 를 저장할 수 있다.
- 한 originalUrl 에 여러 shortUrlCode 가 저장되어 있는 경우, originalUrl 로 shortUrlCode 를 조회할 때 어떤 shortUrlCode 를 반환할 지 알 수 었다.